### PR TITLE
add footer containing legal stuff and contact

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -1,9 +1,12 @@
 :root {
     --background: #eee;
     --text: #111;
+    --footer-text: #555;
     --heading: #333;
     --link: #337;
     --visited-link: #337;
+    --body-margin: 4em;
+    --inner-margin: 1em;
 }
 
 @font-face {
@@ -18,8 +21,8 @@ body {
     font-family: 'Roboto';
     max-width: 50em;
     margin: auto;
-    margin-top: 4em;
-    margin-bottom: 4em;
+    margin-top: var(--body-margin);
+    margin-bottom: var(--body-margin);
     background-color: var(--background);
     color: var(--text);
     overflow-y: scroll;
@@ -59,8 +62,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .collapsible {
-    margin-top: 1em;
-    margin-bottom: 1em;
+    margin: var(--inner-margin) 0;
 }
 
 .toggle {
@@ -87,12 +89,17 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .content {
-    margin: 10px;
+    margin: var(--inner-margin);
     flex-grow: 1;
 }
 
 .footer {
-    margin: 10px;
-    margin-bottom: 0;
-    padding-bottom: 10px;
+    margin: 0 var(--inner-margin);
+    padding-bottom: var(--inner-margin);
+    font-size: small;
+    color: var(--footer-text);
+}
+
+.footer div {
+    padding-top: var(--inner-margin);
 }

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -73,9 +73,26 @@ h1, h2, h3, h4, h5, h6 {
     width: 25%;
     display: flex;
     margin: auto;
+    margin-bottom: 2em;
 }
 
 .section {
-    margin: 10px;
     border-bottom: 1px solid black;
+}
+
+.container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.content {
+    margin: 10px;
+    flex-grow: 1;
+}
+
+.footer {
+    margin: 10px;
+    margin-bottom: 0;
+    padding-bottom: 10px;
 }

--- a/source/index.pug
+++ b/source/index.pug
@@ -22,5 +22,6 @@ html(lang="de")
                 div.section
                     +collapsible("Vereinssatzung")
                         !=require("./docs/Satzung.md")
-            div.footer Das Kleingedruckte
+            div.footer
+                include ./partials/footer.pug
 

--- a/source/index.pug
+++ b/source/index.pug
@@ -6,17 +6,21 @@ html(lang="de")
         meta(charset="UTF-8")
         meta(name = 'keywords', content = `${config.title}, ${config.short}`)
     body
-        div.section
-            img(src=require("./graphics/logo/fullName/logo_textAsPath.svg"), alt="Logo").logo
-            h1 #{config.title}
-            p Der #{config.title} ist ein Bierballclub aus Potsdam. Unser Ziel ist es, Bierball vom Stigma eines Trinkspiels zu befreien und stattdessen als professioniellen Mannschaftssport zu etablieren.
-            p Der Verein befindet sich zurzeit noch im Aufbau. Informationen zum Erwerb einer Mitgliedschaft und geplanten Veranstaltungen werden hier zu gegebener Zeit veröffentlicht.
-        div.section
-            +collapsible("Vereinfachte Spielregeln")
-                !=require("./docs/Spielregeln_kurz.md")
-        div.section
-            +collapsible("Spielregeln")
-                !=require("./docs/Spielregeln.md")
-        div.section
-            +collapsible("Vereinssatzung")
-                !=require("./docs/Satzung.md")
+        div.container
+            div.content
+                div.section
+                    img(src=require("./graphics/logo/fullName/logo_textAsPath.svg"), alt="Logo").logo
+                    h1 #{config.title}
+                    p Der #{config.title} ist ein Bierballclub aus Potsdam. Unser Ziel ist es, Bierball vom Stigma eines Trinkspiels zu befreien und stattdessen als professioniellen Mannschaftssport zu etablieren.
+                    p Der Verein befindet sich zurzeit noch im Aufbau. Informationen zum Erwerb einer Mitgliedschaft und geplanten Veranstaltungen werden hier zu gegebener Zeit veröffentlicht.
+                div.section
+                    +collapsible("Vereinfachte Spielregeln")
+                        !=require("./docs/Spielregeln_kurz.md")
+                div.section
+                    +collapsible("Spielregeln")
+                        !=require("./docs/Spielregeln.md")
+                div.section
+                    +collapsible("Vereinssatzung")
+                        !=require("./docs/Satzung.md")
+            div.footer Das Kleingedruckte
+

--- a/source/js/mail.js
+++ b/source/js/mail.js
@@ -1,0 +1,23 @@
+// this script provides minimal spam protection by only adding the mail address
+// to the document source after user interaction
+
+function show(user, domain, id) {
+    const elem = document.getElementById(id);
+    elem.innerHTML = user + '[at]' + domain;
+    elem.onmouseover = undefined;
+    setTimeout(() => {
+        // delay slightly to avoid accidental invoke when touching to show
+        elem.onclick = () => send(user, domain);
+    }, 100);
+}
+
+function send(user, domain) {
+    const a = document.createElement('a');
+    a.href = `mailto:${user}@${domain}`;
+    a.click();
+}
+
+window.mail = {
+    show,
+    send
+}

--- a/source/partials/footer.pug
+++ b/source/partials/footer.pug
@@ -4,7 +4,7 @@ div
     | .
     br
     | Wir nutzen GitHub Pages zum Hosten der Webseite &ndash; 
-    a(href="https://github.com/Bierball-Club-Potsdam/website") Link zum Privacy Statement
+    a(href="https://docs.github.com/en/github/site-policy/github-privacy-statement#github-pages") Link zum Privacy Statement
     | .
     br
     | Da diese Webseite keine geschäftsmäßigen Dienste im Sinne des 
@@ -16,7 +16,7 @@ div
     | .
     br
     | We use GitHub Pages for hosting &ndash; 
-    a(href="https://github.com/Bierball-Club-Potsdam/website") link to privacy statement
+    a(href="https://docs.github.com/en/github/site-policy/github-privacy-statement#github-pages") link to privacy statement
     | .
 div
     | Kontakt / Contact: 

--- a/source/partials/footer.pug
+++ b/source/partials/footer.pug
@@ -1,0 +1,24 @@
+div
+    | Diese Website erhebt keine Personenbezogen Daten und verwendet keine Cookies &ndash; 
+    a(href="https://github.com/Bierball-Club-Potsdam/website") Link zum Quelltext
+    | .
+    br
+    | Wir nutzen GitHub Pages zum Hosten der Webseite &ndash; 
+    a(href="https://github.com/Bierball-Club-Potsdam/website") Link zum Privacy Statement
+    | .
+    br
+    | Da diese Webseite keine geschäftsmäßigen Dienste im Sinne des 
+    a(href="https://www.gesetze-im-internet.de/tmg/__5.html") TMG §5
+    |  bewirbt, verzichten wir auf die Angabe eines Impressums.
+div
+    | This website does not collect personal information or use cookies &ndash; 
+    a(href="https://github.com/Bierball-Club-Potsdam/website") link to source code
+    | .
+    br
+    | We use GitHub Pages for hosting &ndash; 
+    a(href="https://github.com/Bierball-Club-Potsdam/website") link to privacy statement
+    | .
+div
+    | Kontakt / Contact: 
+    - const mail = "mail.show('admin', 'bierball.club', 'mail')";
+    a(id='mail', onmouseover=mail) [Berühren zum Anzeigen / hover to show]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
@@ -18,8 +18,9 @@ module.exports = function (env, argv) {
     };
 
     const entry = {
-        collapsible: "./source/js/collapsible.js",
-        style: "./source/css/style.css"
+        collapsible: './source/js/collapsible.js',
+        style: './source/css/style.css',
+        mail: './source/js/mail.js'
     };
 
     const plugins = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,12 +101,17 @@ module.exports = function (env, argv) {
         ],
     };
 
+    const devServer = {
+        hot: false
+    }
+
     return {
         output,
         entry,
         plugins,
         module,
         resolve,
-        optimization
+        optimization,
+        devServer
     };
 }


### PR DESCRIPTION
This adds a footer specifying that we don't collect any personal information, as well as providing links to the source code and githubs privacy statement. The footer also contains an admin email address.

Screenshot:  
![screenshot](https://user-images.githubusercontent.com/9416845/132546074-b5293ac6-e36a-430e-9830-cd619fccf5fd.png)
